### PR TITLE
Add API key to BatchLoadingWorker

### DIFF
--- a/lib/best_change/batch_loading_worker.rb
+++ b/lib/best_change/batch_loading_worker.rb
@@ -8,7 +8,8 @@ module BestChange
     sidekiq_options queue: :best_change, retry: false
 
     def perform(exchange_rates, timestamp)
-      `#{BestChange.configuration.fetcher_path} #{exchange_rates} #{timestamp}`
+      api_key = Settings.bestchange_api_key
+      `#{BestChange.configuration.fetcher_path} #{exchange_rates} #{timestamp} #{api_key}`
     end
   end
 end


### PR DESCRIPTION
## Summary

- Добавлена передача `Settings.bestchange_api_key` в команду fetcher
- Изменение извлечено из ветки `legacy`

## Анализ legacy vs master

После анализа выяснилось что **master уже содержит актуальный код**:
- ✅ Repository использует прямой Redis (без DRb)
- ✅ LoadingWorker содержит логику авторейтов
- ✅ Используется `configuration.fetcher_path`

Единственное полезное изменение из legacy — **API key**, который теперь добавлен.

### Ветка legacy может быть удалена
Legacy содержит устаревший код:
- DRb кеш (не нужен)
- Отдельный AutoRateWorker (логика уже в LoadingWorker в master)
- Хардкод путей

## Test plan

- [ ] Убедиться что `Settings.bestchange_api_key` настроен в приложении
- [ ] Проверить что fetcher принимает API key как третий аргумент

🤖 Generated with [Claude Code](https://claude.com/claude-code)